### PR TITLE
Shorten the Docs Name

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,4 +1,4 @@
-name: appuio-cloud-user
+name: user
 title: APPUiO Cloud for Users
 version: master
 start_page: ROOT:index.adoc


### PR DESCRIPTION
This allows for shorter URLs: https://docs.appuio.cloud/appuio-cloud-user/index.html -> https://docs.appuio.cloud/user/index.html