### PR TITLE
Add how-to page to disable default network policies

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,7 @@
 * xref:how-to/list-namespaces.adoc[List Namespaces]
 * xref:how-to/getting-a-certificate.adoc[Generate Certificates]
 * xref:how-to/use-integrated-registry.adoc[Using the integrated registry]
+* xref:how-to/remove-default-networkpolicies.adoc[Remove Default NetworkPolicies]
 
 .Technical reference
 * xref:references/zones.adoc[Zones]

--- a/docs/modules/ROOT/pages/how-to/remove-default-networkpolicies.adoc
+++ b/docs/modules/ROOT/pages/how-to/remove-default-networkpolicies.adoc
@@ -5,10 +5,10 @@ In every namespace 2 `NetworkPolicies` are created and maintained by {product}:
 . `allow-from-other-namespaces`: This policy allows the Router and other system components to connect to the pods.
 . `allow-from-same-namespace`: This policy allows connections between pods in the same namespace.
 
-NOTE: Changes to these policies are reverted to their original state.
+NOTE: {product} automatically reverts any changes made in these policy objects.
 
 If you have the need to customize the default policies, you can remove them and provide your own policies.
-To customize the policies, configure the namespace labels as following:
+You can disable the automatic network policy management of {product} by adding labels to a namespace as shown below.
 
 [source,yaml]
 ----
@@ -26,11 +26,14 @@ metadata:
     network-policies.syn.tools/purge-defaults: 'true' <2>
   name: my-namespace
 ----
-<1> Set this label to prevent reverting the default network policies in case you edit them.
-<2> Set this label to remove the default network policies.
+<1> Add this label to prevent {product} from reverting changes to the default network policies.
+Note that {product} won't recreate the default network policies (for example if they're accidentally deleted) if this label is set to `true`.
+Also note that {product} won't create the default network policies if this label is set to `true` when the namespace is created.
+<2> Add this label only if you want to completely remove the default network policies.
+Note that {product} will remove any network policy which matches the name of one of the default policies if this label is set to `true`.
 
 [WARNING]
 ====
-Removing the defaults without replacing with appropriate policies causes also system components to be locked out from your namespace.
+Removing or modifying the default policies from a namespace without having appropriate replacement policies in place will prevent system components (such as the OpenShift Router) from connecting to applications in the namespace.
 Only do this if you know what you are doing.
 ====

--- a/docs/modules/ROOT/pages/how-to/remove-default-networkpolicies.adoc
+++ b/docs/modules/ROOT/pages/how-to/remove-default-networkpolicies.adoc
@@ -1,0 +1,36 @@
+= Remove Default NetworkPolicies
+
+In every namespace 2 `NetworkPolicies` are created and maintained by {product}:
+
+. `allow-from-other-namespaces`: This policy allows the Router and other system components to connect to the pods.
+. `allow-from-same-namespace`: This policy allows connections between pods in the same namespace.
+
+NOTE: Changes to these policies are reverted to their original state.
+
+If you have the need to customize the default policies, you can remove them and provide your own policies.
+To customize the policies, configure the namespace labels as following:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: My cool project
+    openshift.io/requester: my-username
+  labels:
+    appuio.io/organization: my-company
+    kubernetes.io/metadata.name: my-namespace
+    network-policies.syn.tools/no-defaults: 'true' <1>
+    network-policies.syn.tools/purge-defaults: 'true' <2>
+  name: my-namespace
+----
+<1> Set this label to prevent reverting the default network policies in case you edit them.
+<2> Set this label to remove the default network policies.
+
+[WARNING]
+====
+Removing the defaults without replacing with appropriate policies causes also system components to be locked out from your namespace.
+Only do this if you know what you are doing.
+====


### PR DESCRIPTION
Documents the change in https://github.com/appuio/component-appuio-cloud/pull/43 for the end user

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `how-to`, `tutorial`, `reference`, `explanation`, `cicd`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
