### PR TITLE
Corrected information in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ Just type `make preview` and open your browser at http://localhost:2020. This ev
 === Adding a New Page
 
 . Create new AsciiDoc (`.adoc`) file in the best matching folder according to the described structure under `docs/modules/ROOT/pages/`.
-. Add the file to the navigation under `docs/modules/ROOT/partials/`
+. Add the file to the navigation under `docs/modules/ROOT/`
 
 For removing pages just do the opposite: Remove the file and remove the entry in the navigation.
 


### PR DESCRIPTION
Fixes the path of the `nav.adoc` file in the README.

## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `how-to`, `tutorial`, `reference`, `explanation`, `cicd`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues if applicable.

