### PR TITLE
Use version 10 of the helm chart in the postgresql helm how-to

### DIFF
--- a/docs/modules/ROOT/pages/how-to/install-postgres-db-helm.adoc
+++ b/docs/modules/ROOT/pages/how-to/install-postgres-db-helm.adoc
@@ -77,7 +77,7 @@ Install the PostgreSQL Helm chart with the following command:
 
 [source,shell]
 ----
-helm install -f postgresql-values.yaml --set global.postgresql.postgresqlPassword=<DB_PW> <MY_HELM_INSTANCE_NAME> bitnami/postgresql
+helm install -f postgresql-values.yaml --set global.postgresql.postgresqlPassword=<DB_PW> <MY_HELM_INSTANCE_NAME> --version 10 bitnami/postgresql
 ----
 
 Replace the `<DB_PW>` with your database user password.


### PR DESCRIPTION
The documented approach doesn't work with the latest version (11 at the time of writing) of the helm chart.

Internal reference: APPU-3772