### PR TITLE
Add OpenSearch to Mastodon

### DIFF
--- a/docs/modules/ROOT/examples/example-app-exo-opensearch.yaml
+++ b/docs/modules/ROOT/examples/example-app-exo-opensearch.yaml
@@ -1,5 +1,5 @@
 apiVersion: exoscale.appcat.vshn.io/v1
-kind: ExoscaleOpensearch
+kind: ExoscaleOpenSearch
 metadata:
   name: example-app
 spec:

--- a/docs/modules/ROOT/examples/example-app-mastodon.yaml
+++ b/docs/modules/ROOT/examples/example-app-mastodon.yaml
@@ -77,7 +77,27 @@ spec:
                   name: redis-creds
                   key: REDIS_PASSWORD
             - name: MASTODON_ELASTICSEARCH_ENABLED
-              value: "false"
+              value: "true"
+            - name: MASTODON_ELASTICSEARCH_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_HOST
+            - name: MASTODON_ELASTICSEARCH_PORT_NUMBER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_PORT
+            - name: MASTODON_ELASTICSEARCH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_USER
+            - name: MASTODON_ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_PASSWORD
             - name: SMTP_SERVER
               value: inbucket-smtp
             - name: SMTP_PORT
@@ -140,7 +160,27 @@ spec:
                   name: redis-creds
                   key: REDIS_PASSWORD
             - name: MASTODON_ELASTICSEARCH_ENABLED
-              value: "false"
+              value: "true"
+            - name: MASTODON_ELASTICSEARCH_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_HOST
+            - name: MASTODON_ELASTICSEARCH_PORT_NUMBER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_PORT
+            - name: MASTODON_ELASTICSEARCH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_USER
+            - name: MASTODON_ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_PASSWORD
             - name: SMTP_SERVER
               value: inbucket-smtp
             - name: SMTP_PORT
@@ -223,7 +263,27 @@ spec:
                   name: redis-creds
                   key: REDIS_PASSWORD
             - name: MASTODON_ELASTICSEARCH_ENABLED
-              value: "false"
+              value: "true"
+            - name: MASTODON_ELASTICSEARCH_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_HOST
+            - name: MASTODON_ELASTICSEARCH_PORT_NUMBER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_PORT
+            - name: MASTODON_ELASTICSEARCH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_USER
+            - name: MASTODON_ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-creds
+                  key: OPENSEARCH_PASSWORD
             - name: DB_SSLMODE
               value: "true"
             - name: NODE_EXTRA_CA_CERTS

--- a/docs/modules/ROOT/pages/tutorials/demo-app/mastodon.adoc
+++ b/docs/modules/ROOT/pages/tutorials/demo-app/mastodon.adoc
@@ -19,7 +19,7 @@ include::partial$app-demo-partials.adoc[tag=step1]
 To deploy the application we will use standard Kubernetes objects.
 Save the example YAML Kubernetes resources into a file and apply it with `oc apply -f <myfile.yaml>`.
 
-. First, we need a database and a cache:
+. First, we need a database, a cache and a search index:
 +
 .Database ordering from the VSHN Application Catalog
 [source,yaml]
@@ -27,10 +27,12 @@ Save the example YAML Kubernetes resources into a file and apply it with `oc app
 include::example$example-app-exo-postgresql.yaml[]
 ---
 include::example$example-app-exo-redis.yaml[]
+---
+include::example$example-app-exo-opensearch.yaml[]
 ----
 +
-This will create a PosgtreSQL and a Redis DBaaS instance with default settings.
-See xref:appcat:ROOT:exoscale-dbaas/postgresql/create.adoc[the AppCat docs for PostgreSQL] and xref:appcat:ROOT:exoscale-dbaas/redis/create.adoc[the AppCat docs for Redis] for more information.
+This will create a PosgtreSQL, a Redis and an OpenSearch DBaaS instance with default settings.
+See xref:appcat:ROOT:exoscale-dbaas/postgresql/create.adoc[the AppCat docs for PostgreSQL], xref:appcat:ROOT:exoscale-dbaas/redis/create.adoc[the AppCat docs for Redis] and xref:appcat:ROOT:exoscale-dbaas/opensearch/create.adoc[the AppCat docs for OpenSearch] for more information.
 
 . And we need some other supporting services for Mastodon to be able to work:
 +


### PR DESCRIPTION
This would add OpenSearch to Mastodon, but it won't work because Mastodon doesn't support encrypted connections to Elasticsearch / OpenSearch and it also doesn't seem to fully support / work with OpenSearch.

I'll leave this PR in draft at this time, maybe support for https will be added in the future.

Refs:
- https://github.com/bitnami/containers/blob/main/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh#L434
- https://github.com/mastodon/mastodon/issues/18535
- https://github.com/mastodon/mastodon/issues/17208
- https://docs.joinmastodon.org/admin/optional/elasticsearch/