### PR TITLE
Extend slow pod startup how-to with `fsGroupChangePolicy`

### DIFF
--- a/docs/modules/ROOT/pages/how-to/long-pod-startup.adoc
+++ b/docs/modules/ROOT/pages/how-to/long-pod-startup.adoc
@@ -5,12 +5,12 @@ This page describes how you can mitigate very long Pod startup times and `Create
 == Explanation
 
 When a Pod mounts a volume which contains many files, the Pod startup time can be very long.
-This is caused because the container runtime updates the SELinux labels of all the files in the volume on Pod startup.
+This is caused because the container runtime updates the group ownership and SELinux labels of all the files in the volume on Pod startup.
 Depending on the number of files, relabeling can take a long time.
 
 When relabeling takes too long, the Pod goes into `CreateContainerError` status after some time.
-When the container is created again, the container runtime continues relabeling files where it left off.
-Depending on the amount of files, multiple container restarts are required before the relabeling is done.
+When the container is created again, the container runtime continues updating group ownership and relabeling files where it left off.
+Depending on the amount of files, multiple container restarts are required before the group ownership updates and relabeling is done.
 Once the relabeling is complete, the Pod will go into status `Running`.
 
 == Implementation
@@ -48,19 +48,23 @@ spec:
   template:
     spec:
       securityContext:
+        fsGroupChangePolicy: OnRootMismatch <1>
         seLinuxOptions:
-          type: spc_t
+          type: spc_t <2>
 ...
 --
+<1> Configure the deployment to only change permissions and ownership for files in the volume if the permission and ownership of the root directory doesn't not match the expected permissions.
+<2> Use SELinux option `spc_t` to ensure the container runtime doesn't try to relabel all files on the volume.
 
 You can also use `oc patch` to change the `securityContext` of the Deployment:
 
 [source,shell]
 --
-oc patch deployment [YOUR_DEPLOYMENT_NAME] -p '{"spec":{"template":{"spec":{"securityContext":{"seLinuxOptions":{"type":"spc_t"}}}}}}'
+oc patch deployment [YOUR_DEPLOYMENT_NAME] -p '{"spec":{"template":{"spec":{"securityContext":{"fsGroupChangePolicy":"OnRootMismatch","seLinuxOptions":{"type":"spc_t"}}}}}}'
 --
 
-For more information, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#selinuxoptions-v1-core[SELinuxOptions Spec].
+For more information on `fsGroupChangePolicy`, see the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods[Kubernetes documentation on configuring volume permission and ownership change].
+For more information on SELinux options, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#selinuxoptions-v1-core[SELinuxOptions Spec].
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
We've seen that changing the CephFS CSI driver config to use `fsGroupPolicy: File` causes slow pod starts for CephFS volumes with many files, because the container runtime unconditionally updates the group permissions and ownership for all files on each pod start by default.

Setting `fsGroupChangePolicy: OnRootMismatch` instructs the container runtime to only update group permissions and ownership when the root directory's group doesn't match the fsGroup of the pod. In combination with SELinux type `spc_t`, this fixes the slow pod startup when the CSI driver is configured with `fsGroupPolicy: File`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `how-to`, `tutorial`, `reference`, `explanation`, `cicd`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
