### PR TITLE
Add step to deploy a `CiliumNetworkPolicy` in the LoadBalancer how-to

### DIFF
--- a/docs/modules/ROOT/pages/how-to/non-http-services.adoc
+++ b/docs/modules/ROOT/pages/how-to/non-http-services.adoc
@@ -52,6 +52,25 @@ spec:
     app: ggircd
 --
 
+Configure a `CiliumNetworkPolicy` to allow access to all workloads in the namespace from outside the cluster:
+
+[source,yaml]
+--
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-from-world
+spec:
+  endpointSelector: {} <1>
+  ingress: <2>
+  - fromEntities:
+    - world
+--
+<1> By configuring a more restrictive `endpoointSelector` you can restrict which workloads are reachable from outside the cluster
+<2> This example policy allows traffic from anywhere outside the cluster (via https://docs.cilium.io/en/latest/security/policy/language/#entities-based[entity] `world`).
+
+TIP: See the https://docs.cilium.io/en/latest/security/policy/[Cilium Network Policy documentation] for a detailed overview of what configuration options are available with `CiliumNetworkPolicy`.
+
 On the https://portal.appuio.cloud/zones/cloudscale-lpg-2[cloudscale.ch - LPG 2] zone, the cluster automatically assigns a unique external IPv4 address to this service. To see which IPv4 address has been assigned, go to the OpenShift Web Console and navigate to "Networking/Services." The IP is displayed in the field "External IP."
 
 Using the CLI is also possible:


### PR DESCRIPTION
With the updated Cilium config (`kubeProxyReplacement="true"`), we need to deploy a `CiliumNetworkPolicy` in order to make LoadBalancer services accessible from outside the cluster.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `how-to`, `tutorial`, `reference`, `explanation`, `cicd`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
