### PR TITLE
Update `activeDeadlineSeconds` default value documentation

### DIFF
--- a/docs/modules/ROOT/pages/references/default-quota.adoc
+++ b/docs/modules/ROOT/pages/references/default-quota.adoc
@@ -54,12 +54,20 @@ Generally, that's pods created by Jobs, CronJobs, or OpenShift Builds.
 Notably, {product} only applies the default value for `.spec.activeDeadlineSeconds` for pods which don't have a value for that field already.
 Therefore, if you need a job to run longer than the default 30 minutes, simply set `.spec.activeDeadlineSeconds` accordingly in the Job's pod template.
 
-Additionally, the default value for `activeDeadlineSeconds` can be adjusted per namespace by adding annotation `appuio.io/active-deadline-seconds-override` to the namespace.
-
 [NOTE]
 ====
 This mechanism ensures that all pods created by Jobs, CronJobs and OpenShift builds are considered `Terminating` by the Kubernetes resource quota management.
 That means that the `organization-compute-terminating` quota is relevant for pods created by Jobs, CronJobs and OpenShift builds.
+====
+
+The default value for `activeDeadlineSeconds` can be adjusted per namespace by adding annotation `appuio.io/active-deadline-seconds-override` to the namespace.
+The implementation expects that the value of the annotation is provided in seconds as a plain number, for example `appuio.io/active-deadline-seconds-override: 3600` to set the default deadline to 1 hour.
+
+[NOTE]
+====
+If the value of the annotation can't be parsed as a number, "run-once" pods won't be scheduled correctly.
+Please check the events in the namespace or the relevant pod controller for details regarding the error.
+For example, for a CronJob, check the generated Job object for errors.
 ====
 
 == Checking the Quota and Limit values


### PR DESCRIPTION
Explicitly note that invalid annotation values to override the namespace limit will cause pod creation failures and give some tips on how to investigate.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `how-to`, `tutorial`, `reference`, `explanation`, `cicd`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
