### PR TITLE
Update github-helm RBAC options

### DIFF
--- a/docs/modules/ROOT/pages/how-to/connect-gitlab.adoc
+++ b/docs/modules/ROOT/pages/how-to/connect-gitlab.adoc
@@ -45,7 +45,8 @@ GITLAB_AGENT_TOKEN=<the-token> <1>
 helm upgrade --install gitlab-agent gitlab/gitlab-agent \
     --set config.token=${GITLAB_AGENT_TOKEN} \
     --set config.kasAddress=wss://kas.gitlab.com \
-    --set rbac.create=false
+    --set rbac.create=false \
+    --set config.operational_container_scanning.enabled=false
 --
 <1> The GitLab Agent's access token
 


### PR DESCRIPTION
Since https://gitlab.com/gitlab-org/charts/gitlab-agent/-/commit/744f04cce350b7ba35ebdddf251dce417bad93c6, there's another option adding RBAC's for the Gitlab agent. As these cannot be setup on APPUiO, marking this as false.